### PR TITLE
Fix: upload workflow 압축 스크립트 전 빌드 실행하도록 수정

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm run pack
+        run: pnpm run build && pnpm run pack
       - name: Uploading Chrome Browser Extension
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## 요약

- upload workflow 압축 실행 스크립트 전에 빌드 먼저 실행하도록 수정합니다.

`pnpm run build` 명령어를 실행해서 압축에 필요한 파일을 얻기 위함입니다.