### PR TITLE
Feat: fsd layer 모듈 상호작용 규칙 작성

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "react"],
+  "plugins": ["@typescript-eslint", "react", "fsd-internal"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -35,5 +35,11 @@
     "react/jsx-uses-react": "off",
     "react/no-unknown-property": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "fsd-internal/layer-imports": [
+      "error",
+      {
+        "alias": "~",
+      },
+    ],
   },
 }

--- a/eslint/fsd/index.js
+++ b/eslint/fsd/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'layer-imports': require('./layer-imports'),
+  },
+};

--- a/eslint/fsd/layer-imports.js
+++ b/eslint/fsd/layer-imports.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Get the current file layer.
+ *
+ * @example
+ * ```js
+ * getCurrentFileLayer('src/shared/ui/button.tsx');
+ * // => 'shared'
+ *
+ * getCurrentFileLayer('src/entities/theme/model/use-dark.ts');
+ * // => 'entities'
+ * ```
+ */
+function getCurrentFileLayer(currentFilePath) {
+  const normalizedPath = currentFilePath.replace(/\\/g, '/');
+  const projectPath = normalizedPath?.split('src')[1];
+  const segments = projectPath?.split('/');
+
+  return segments?.[1];
+}
+
+exports.create = function create(context) {
+  const { alias = '' } = context.options[0] ?? {};
+
+  const layers = {
+    background: ['background', 'widgets', 'features', 'entities', 'shared'],
+    contentScripts: ['contentScripts', 'widgets', 'features', 'entities', 'shared'],
+    options: ['options', 'widgets', 'features', 'entities', 'shared'],
+    widgets: ['features', 'entities', 'shared'],
+    features: ['entities', 'shared'],
+    entities: ['entities', 'shared'],
+    shared: ['shared'],
+  };
+
+  const availableLayers = Object.keys(layers);
+
+  const getImportLayer = (value) => {
+    const importPath = alias ? value.replace(new RegExp(`^${alias}/`), '') : value;
+    const segments = importPath.split('/');
+
+    return segments.find((segment) => availableLayers.includes(segment));
+  };
+
+  /**
+   * @example
+   * // src/shared/ui/button.tsx
+   * import a from '../lib/env';
+   * import a1 from '~/shared/lib/env';
+   * import b from './label';
+   * import b1 from '~/shared/ui/label';
+   * import z from '../../entities/...'; // trigger error!
+   * import z1 from '~/entities/...'; // trigger error!
+   * import z2 from '~/shared/features/...'; // trigger error!
+   */
+  return {
+    ImportDeclaration(node) {
+      const { value } = node.source;
+      const currentFileLayer = getCurrentFileLayer(context.getFilename());
+      const importLayer = getImportLayer(value);
+
+      if (!importLayer) {
+        return;
+      }
+
+      const isAllowed = layers[currentFileLayer].includes(importLayer);
+
+      if (!isAllowed) {
+        context.report({
+          node,
+          message: `Importing from "${importLayer}" is not allowed in the current layer "${currentFileLayer}".`,
+        });
+      }
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "esbuild": "^0.20.2",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-fsd-internal": "link:./eslint/fsd",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-vitest": "^0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@8.57.0)
+      eslint-plugin-fsd-internal:
+        specifier: link:./eslint/fsd
+        version: link:eslint/fsd
       eslint-plugin-react:
         specifier: ^7.34.1
         version: 7.34.1(eslint@8.57.0)


### PR DESCRIPTION
## 요약

- FSD 아키텍처의 레이어 모듈 상호작용 규칙을 설정합니다.

## FSD 아키텍처의 레이어 모듈

![image](https://github.com/jaem1n207/dynamic-scrollbar/assets/50766847/b4d499ad-9ffa-4fdf-ba15-a53648603e68)

- `features` 레이어가 `entities` 레이어보다 더 위에 있기에 `entities` 레이어는 `features` 레이어의 모듈을 사용할 수 없습니다. 이러한 선형적인 흐름을 자동으로 관리하기 위해 작성했습니다.
- 브라우저 익스텐션 구조에 맞게끔 조금 변형해서 사용하기에 직접 규칙을 정의합니다.

## 참고

https://emewjin.github.io/feature-sliced-design/#%EB%A0%88%EC%9D%B4%EC%96%B4